### PR TITLE
Support "metadata" in Rosbag

### DIFF
--- a/fdwli3ds/foreignpc.py
+++ b/fdwli3ds/foreignpc.py
@@ -5,6 +5,8 @@ import xml.etree.ElementTree as etree
 
 from multicorn import ForeignDataWrapper
 
+from .util import strtobool
+
 
 # used to store dimension details
 dimension = namedtuple('dimensions', ['name', 'size', 'type', 'scale'])
@@ -29,7 +31,7 @@ class ForeignPcBase(ForeignDataWrapper):
         # pcid used to create WKB patchs
         self.pcid = int(options.get('pcid', 0))
         # next option is used to retrieve pcschema.xml back to postgres
-        self.metadata = options.get('metadata', False)
+        self.metadata = strtobool(options.get('metadata', 'false'))
         # get time offset if provided
         self.time_offset = float(options.get('time_offset', 0))
         # will store dimension infos

--- a/fdwli3ds/util.py
+++ b/fdwli3ds/util.py
@@ -1,0 +1,2 @@
+def strtobool(v):
+    return v.lower() in ('yes', 'true', 't', '1')

--- a/readme.md
+++ b/readme.md
@@ -96,7 +96,7 @@ create server sbetserver foreign data wrapper multicorn
 create foreign table mysbet_schema (
     schema text
 )
-server sbeserver
+server sbetserver
  options (
     metadata 'true'
 );

--- a/readme.md
+++ b/readme.md
@@ -154,9 +154,19 @@ select * from rosbag_imu limit 20;
 Create foreign table for the `/Laser/velodyne_points` topic:
 
 ```sql
+create foreign table rosbag_pointcloud2_format (
+    schema text
+) server rosbagserver
+    options (
+        topic '/Laser/velodyne_points'
+        , metadata 'true'
+);
+
+insert into pointcloud_formats (pcid, srid, schema)
+select 3, 4326, schema from rosbag_pointcloud2_format;
+
 create foreign table rosbag_pointcloud2 (
-    schema character varying
-    , patch pcpatch(3)
+    patch pcpatch(3)
     , ply bytea
     , width int
     , height int
@@ -167,11 +177,6 @@ create foreign table rosbag_pointcloud2 (
         , max_count '10000'
 );
 
--- register the pointcloud schema (only once!)
-insert into pointcloud_formats
-select 3 as pcid, 4326 as srid, schema
-from rosbag_pointcloud2
-limit 1;
 
 select sum(width*height) from rosbag_pointcloud2;
 select sum(pc_numpoints(patch)) from rosbag_pointcloud2;

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ create extension if not exists pointcloud;
 drop extension multicorn cascade;
 create extension multicorn;
 
-create server echopulse foreign data wrapper multicorn
+create server echopulseserver foreign data wrapper multicorn
     options (
         wrapper 'fdwli3ds.EchoPulse'
         , directory 'data/echopulse'
@@ -65,7 +65,7 @@ create server echopulse foreign data wrapper multicorn
 create foreign table myechopulse_schema (
     schema text
 )
-server echopulse
+server echopulseserver
     options (
         metadata 'true'
     );
@@ -75,7 +75,7 @@ select 1, -1, schema from myechopulse_schema;
 
 create foreign table myechopulse (
     points pcpatch(1)
-) server echopulse
+) server echopulseserver
     options (
         patch_size '400'
         , pcid '1'

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,7 @@ create extension multicorn;
 create server echopulse foreign data wrapper multicorn
     options (
         wrapper 'fdwli3ds.EchoPulse'
+        , directory 'data/echopulse'
     );
 
 -- create foreign table to retrieve the pointcloud schema dynamically
@@ -66,8 +67,7 @@ create foreign table myechopulse_schema (
 )
 server echopulse
     options (
-        directory 'data/echopulse'
-        , metadata 'true'
+        metadata 'true'
     );
 
 insert into pointcloud_formats(pcid, srid, schema)
@@ -77,8 +77,7 @@ create foreign table myechopulse (
     points pcpatch(1)
 ) server echopulse
     options (
-        directory 'data/echopulse'
-        , patch_size '400'
+        patch_size '400'
         , pcid '1'
     );
 


### PR DESCRIPTION
This PR adds a "metadata" option to the Rosbag FDW. The Sbet and EchoPulse FDWs already have that option, so this PR brings some consistency across the FDWs.

Fixes #12.

This is how the "metadata" option is used:

```sql
create foreign table rosbag_pointcloud2_format (
    schema text
) server rosbagserver
    options (
        topic '/Laser/velodyne_points'
        , metadata 'true'
);

insert into pointcloud_formats (pcid, srid, schema)
select 3, 4326, schema from rosbag_pointcloud2_format;
```

When `import foreign schema` is used a *format* table is created for each `sensor_msgs/PointCloud2` topic found in the rosbag file. The name of the table is `<topic_name>_format` (e.g. `/Laser/velodyne_points_format`).

In the future we may want to implement what is described #1 and create one `pointcloud_formats` table per bag file (instead of per `sensor_msgs/PointCloud2` topic.