### PR TITLE
Sbet overlap

### DIFF
--- a/fdwli3ds/echopulse.py
+++ b/fdwli3ds/echopulse.py
@@ -203,7 +203,7 @@ class EchoPulse(ForeignPcBase):
         # check consistency, sub directories must have the same number of files
         if len(source_files_count) != 1:
             raise Exception('Consistency failed, bad number of files in '
-                            'source directories')
+                            'source directories {}'.format(str(source_files_count)))
 
         framelist = []
 
@@ -236,7 +236,6 @@ class EchoPulse(ForeignPcBase):
             # read frame
             att_array = self.read_ept(frame)
             att_size = len(att_array[0][1])
-
             # generating slices for accessing subarrays
             # [slice(0, 100),
             #  slice(100, 200),
@@ -284,7 +283,6 @@ class EchoPulse(ForeignPcBase):
             np.ones(nentries, dtype='float64') * t0 +
             np.arange(nentries, dtype='float64') * delta
         )
-
         echo_arrays = {}
         echos = frame['echo']
 

--- a/fdwli3ds/sbet.py
+++ b/fdwli3ds/sbet.py
@@ -41,7 +41,7 @@ class Sbet(ForeignPcBase):
                                      'schemas', 'sbetschema.xml')
         # add overlap option (which add the previous point in each patch and build
         # a continuous timeline for trajectories)
-        self.overlap = strtobool(options.get('overlap', 'False'))
+        self.overlap = strtobool(options.get('overlap', 'True'))
 
     def execute(self, quals, columns):
         # When the metadata parameter has been passed to the foreign table

--- a/fdwli3ds/sbet.py
+++ b/fdwli3ds/sbet.py
@@ -10,6 +10,7 @@ import numpy as np
 from multicorn.utils import log_to_postgres
 
 from .foreignpc import ForeignPcBase
+from .util import strtobool
 
 
 class Sbet(ForeignPcBase):
@@ -38,6 +39,9 @@ class Sbet(ForeignPcBase):
         # sbet schema is provided
         self.pcschema = os.path.join(os.path.dirname(__file__),
                                      'schemas', 'sbetschema.xml')
+        # add overlap option (which add the previous point in each patch and build
+        # a continuous timeline for trajectories)
+        self.overlap = strtobool(options.get('overlap', 'False'))
 
     def execute(self, quals, columns):
         # When the metadata parameter has been passed to the foreign table
@@ -103,7 +107,10 @@ class Sbet(ForeignPcBase):
             # append the end of the array
             slices.append(slice(slices[-1].stop, sbet_size))
 
-        for sli in slices:
+        last_one = None
+
+        for idx, sli in enumerate(slices):
+
             subarray = sbet[sli]
             # convert to degrees and apply scale factor
             subarray['x'] = rad2deg_scaled_x * subarray['x']
@@ -112,5 +119,14 @@ class Sbet(ForeignPcBase):
             subarray['m_time'] += self.time_offset
             # cast to pointcloud xml schema types
             subarray = subarray.astype(sbet_patch_type)
-            header = pack('<b3I', 1, self.pcid, 0, sli.stop - sli.start)
-            yield {'points': hexlify(header + subarray.tostring())}
+
+            if idx > 0 and self.overlap:
+                header = pack('<b3I', 1, self.pcid, 0, sli.stop - sli.start + 1)
+                data = hexlify(header + last_one.tostring() + subarray.tostring())
+                # overlap option: repeat the last values from the previous patch
+                last_one = subarray[-1]
+                yield {'points': data}
+            else:
+                header = pack('<b3I', 1, self.pcid, 0, sli.stop - sli.start)
+                last_one = subarray[-1]
+                yield {'points': hexlify(header + subarray.tostring())}

--- a/fdwli3ds/util.py
+++ b/fdwli3ds/util.py
@@ -15,7 +15,7 @@ def extract_dimension(patch, dimensions, name, compression=None):
     if not compression:
         dtype = [(dim.name, dim.type) for dim in dimensions]
         # convert to degrees and apply scale factor
-        return np.fromstring(patch[13:], dtype=dtype)
+        return np.fromstring(patch[13:], dtype=dtype)[name]
 
     if compression == 'dimensional':
         dim_header = 5

--- a/fdwli3ds/util.py
+++ b/fdwli3ds/util.py
@@ -1,2 +1,34 @@
+import struct
+
+import numpy as np
+
+
 def strtobool(v):
     return v.lower() in ('yes', 'true', 't', '1')
+
+
+def extract_dimension(patch, dimensions, name, compression=None):
+    '''
+    Extract a dimension in a patch with dimensional compression.
+    Returns a numpy array
+    '''
+    if not compression:
+        dtype = [(dim.name, dim.type) for dim in dimensions]
+        # convert to degrees and apply scale factor
+        return np.fromstring(patch[13:], dtype=dtype)
+
+    if compression == 'dimensional':
+        dim_header = 5
+        # compute the offset needed to find the dimension
+        # first offset is for the patch header
+        offset = 13
+        for dim in dimensions:
+            # skip dimensional type on 1b
+            dimsize = int(struct.unpack('<I', patch[offset + 1: offset + 5])[0])
+            if dim.name == name:
+                # dimension found!
+                break
+            offset += dim_header + dimsize
+        return np.fromstring(
+            patch[offset + dim_header:offset + dim_header + dimsize],
+            dtype=dim.type)

--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ create foreign table myechopulse (
 ) server echopulseserver
     options (
         patch_size '400'
-        , pcid '1'
+        , pcid '1' 
     );
 
 select * from myechopulse;
@@ -113,6 +113,7 @@ create foreign table mysbet (
         sources 'data/sbet/sbet.bin'
         , patch_size '100'
         , pcid '2'
+        , overlap 'true' -- overlaps avoids time gaps between patches
 );
 
 

--- a/readme.md
+++ b/readme.md
@@ -113,7 +113,7 @@ create foreign table mysbet (
         sources 'data/sbet/sbet.bin'
         , patch_size '100'
         , pcid '2'
-        , overlap 'true' -- overlaps avoids time gaps between patches
+        , overlap 'true' -- overlaps avoids time gaps between patches 'true' by default
 );
 
 

--- a/test/test_sbet.py
+++ b/test/test_sbet.py
@@ -107,6 +107,7 @@ def test_point_count(reader):
     """
     All patch must have the correct number of points (5000 in the test file)
     """
+    reader.overlap = False
     allpatch = list(reader.execute(None, None))
     # header size for each patch
     header_size = 13
@@ -135,6 +136,7 @@ def test_time_offset(reader_offset, reader):
 
 
 def test_nonoverlap_patch(reader):
+    reader.overlap = False
     read = reader.execute(None, None)
     first_patch = unhexlify(next(read)['points'])
     second_patch = unhexlify(next(read)['points'])

--- a/test/test_sbet.py
+++ b/test/test_sbet.py
@@ -30,7 +30,7 @@ def reader_offset(scope='module'):
         options={
             'sources': sbet_file,
             'pcid': '1',
-            'timeoffset': '1300000'
+            'time_offset': '1300000'
         },
         columns=None
     )
@@ -116,6 +116,22 @@ def test_point_count(reader):
     ])
     point_size = sum(int(dim.size) for dim in reader.dimensions)
     assert allpatch_size / point_size == 50000
+
+
+def test_time_offset(reader_offset, reader):
+    patch = next(reader.execute(None, None))
+    patch_offset = next(reader_offset.execute(None, None))
+    patch_nohead = unhexlify(patch['points'])
+    patch_offset_nohead = unhexlify(patch_offset['points'])
+    times = extract_dimension(
+        patch_nohead,
+        reader.dimensions,
+        'm_time')
+    times_offset = extract_dimension(
+        patch_offset_nohead,
+        reader_offset.dimensions,
+        'm_time')
+    assert times_offset[0] - times[0] == 1300000
 
 
 def test_nonoverlap_patch(reader):


### PR DESCRIPTION
this adds an option to duplicate the last point of a patch to the beginning of the next one. Since all patches are read in time order, that prevents to have time gaps between patches.

Without overlap : 
![woverlap](https://user-images.githubusercontent.com/1412193/29556299-b3c1df88-8725-11e7-947b-8331f9c73f90.png)

With overlap: 
![overlap](https://user-images.githubusercontent.com/1412193/29556302-b5401b54-8725-11e7-8f70-55b670f29b91.png)






 